### PR TITLE
feat: added multitenant seeding and switching

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -194,6 +194,12 @@ All validation uses Zod schemas from `@spectatr/shared-types` package.
 ## Current Implementation Status
 
 **Completed:**
+- ✅ **Multi-tenant seed data** - `trc-2025` (160 players) + `super-2026` (441 players)
+  - Seed: `npm run db:seed -- --tenant trc-2025` or `--all`
+  - Dev switching: append `?tenant=super-2026` to URL (persists in sessionStorage)
+- ✅ **Dual-layer tenant isolation** - See [Multi-Tenancy Architecture](../ARCHITECTURE.md#multi-tenancy-architecture)
+  - PostgreSQL RLS (`spectatr_app` role) + Prisma app-level `tenantId` injection
+  - `useTenantQuery` hook auto-scopes TanStack Query cache keys by tenant
 - ✅ **Backend API with tRPC** - See [Backend API Guide](copilot-instructions/backend-api.md)
   - Multi-tenant architecture, Prisma ORM, PostgreSQL
   - Rate limiting (Redis), audit trail, background jobs
@@ -203,17 +209,12 @@ All validation uses Zod schemas from `@spectatr/shared-types` package.
   - JWT verification in Express middleware
   - User persistence with provider-agnostic IDs
   - Route guards (public dashboard, protected routes)
-  - Auth + tenant middleware composition
 - ✅ Monorepo structure with shared-types package
 - ✅ Theme system with 3 themes (rugby, light, dark) and custom tokens
-- ✅ Custom themed components (PlayerSlot, EmptySlot)
 - ✅ Dashboard with table view (public access)
-- ✅ React Router navigation with route protection
 - ✅ Player list with filtering (FilterPanel, PlayerListItem, PlayerList)
-- ✅ Field layout configuration system
 - ✅ Zustand store (myTeamStore) with validation integration
-- ✅ Storybook component testing (replaces test page)
-- ✅ Vitest unit testing
+- ✅ Storybook component testing + Vitest unit testing
 
 **In Progress:**
 - Field visualization view
@@ -240,9 +241,8 @@ All validation uses Zod schemas from `@spectatr/shared-types` package.
 - Use the [plan template](plan-template.md) for new implementation plans
 
 **Mock Data:**
-- `data/trc-2025/players.json` - Full player dataset
-- `data/trc-2025/squads.json` - Real-world team data
-- `data/trc-2025/rounds.json` - Round/fixture data
+- `data/trc-2025/` - The Rugby Championship 2025 (160 players, 4 squads, 16 rounds)
+- `data/super-2026/` - Super Rugby Pacific 2026 (441 players, 11 squads, 16 rounds)
 - `packages/ui/src/mocks/leagues.json` - Sample leagues
 - `packages/ui/src/mocks/leagueRules.json` - League rule configurations
 

--- a/.github/copilot-instructions/plans/plan-seedDataAndMultiTenantSwitching.prompt.md
+++ b/.github/copilot-instructions/plans/plan-seedDataAndMultiTenantSwitching.prompt.md
@@ -1,0 +1,338 @@
+# Implementation Plan: Multi-Tenant Seed Data & Tenant Switcher
+
+Enable seeding of `super-2026` (Super Rugby Pacific) as a fully isolated second tenant, replace the hardcoded `x-tenant-id` header in the API client with a dev-time query-param override, fix squad name lookups to use API-sourced data, and clear client stores on tenant switch. The DB schema and tRPC routers require no changes — all gaps are in the seed script, API client, two player-list components, and `myTeamStore`.
+
+---
+
+## Architecture and Design
+
+### High-Level Architecture
+
+The DB schema is **already fully multi-tenant** — every data model has a `tenantId` FK. The gaps are entirely in:
+
+1. The **seed script** — hardcoded to `trc-2025`
+2. The **frontend API client** — hardcoded `x-tenant-id: 'trc-2025'` header
+3. The **frontend squad name lookups** — importing static `@data/trc-2025/squads.json`
+
+The plan does **not** touch the backend tRPC routers. One small schema change is included: removing the hardcoded `@default(42000000)` from `Team.budget` (currently unused and rugby-specific).
+
+### Tenant Resolution Flow
+
+```
+Development
+  URL ?tenant=super-2026              ← highest priority (ad-hoc override)
+  sessionStorage 'spectatr-dev-tenant' ← persists across React Router navigation
+  VITE_TENANT_ID=trc-2025 (env var)   ← session default
+  hardcoded fallback: 'trc-2025'
+
+Production
+  Cloudflare / DNS injects x-tenant-id header from subdomain/domain alias
+  DEV code path is never reached (import.meta.env.DEV guard is dead code)
+
+Frontend (both)
+  getActiveTenantId() utility
+    └─ reads: new URLSearchParams(window.location.search).get('tenant')
+    └─ persists to: sessionStorage('spectatr-dev-tenant')
+    └─ falls back to: import.meta.env.VITE_TENANT_ID
+    └─ falls back to: 'trc-2025'
+
+  useTenant() hook
+    └─ wraps getActiveTenantId()
+    └─ single source of tenantId for query cache keys + UI display
+
+  fetchTrpc / client.ts
+    └─ calls getActiveTenantId() per request
+    └─ injects 'x-tenant-id': tenantId header
+
+  TanStack Query
+    └─ all query keys include tenantId: ['players', tenantId]
+```
+
+### Key Data Differences: super-2026 vs trc-2025
+
+| Aspect | trc-2025 | super-2026 | Action |
+|---|---|---|---|
+| Rounds schema | Flat `matches` array | Rounds contain nested `tournaments` array | Normalize in seed script |
+| Player images | `/player-images/portrait/{Name}-{id}.jpg` | `image/profile/{feedId}.png` | **Deferred — see docs/PLAYER_IMAGES.md** |
+| `priceHistory` field | Not present | `{ "1": 2500000, ... }` (round→price map) | Store in Player `stats` JSONB |
+| `player_stats.json` | Not present | Per-player detailed stats (tries, tackles, etc.) | Merge into Player `stats` JSONB during seed |
+| Squad badges | `badge: null` | `image/badges/{ABBR}.png` | Store in Squad as-is |
+| Sport | rugby-union | rugby-union | No sport config change needed |
+
+### Component Breakdown
+
+**New:**
+- `packages/ui/src/utils/tenant.ts` — `getActiveTenantId()` pure utility (DEV-only query param + sessionStorage; env var fallback in all modes)
+- `packages/ui/src/hooks/useTenant.ts` — `useTenant()` React hook wrapping `getActiveTenantId()`; returns `{ tenantId }`
+- `docs/PLAYER_IMAGES.md` — image naming constraint documentation
+
+**Modified:**
+- `packages/server/prisma/schema.prisma` — remove `@default(42000000)` from `Team.budget`
+- `packages/server/src/scripts/seed.ts` — parameterized, iterates `TENANT_CONFIGS` map
+- `packages/ui/src/hooks/api/client.ts` — calls `getActiveTenantId()` per request
+- All existing TanStack Query hooks — `tenantId` added to cache keys
+- `packages/ui/src/features/players/PlayerList.tsx` — consume `useSquadsQuery`, pass `squads` to children
+- `packages/ui/src/features/players/PlayerListItem.tsx` — accept `squads: Squad[]` prop, remove static mock import
+- `packages/ui/src/features/players/FilterPanel.tsx` — accept squads as prop if currently using static data
+- `packages/ui/src/mocks/playerData.ts` — deprecate `getSquadById` / `getSquadName`
+- `myTeamStore` — reset on tenant mismatch at initialisation
+
+**Documentation:**
+- `packages/server/START.md` — multi-tenant seeding steps
+- `ARCHITECTURE.md` — tenant resolution section update
+
+### Data Model
+
+**Tenant config map (seed script):**
+```typescript
+const TENANT_CONFIGS: Record<string, TenantSeedConfig> = {
+  'trc-2025': {
+    id: 'trc-2025',
+    name: 'The Rugby Championship 2025',
+    slug: 'trc-2025',
+    sportType: 'rugby-union',
+    primaryColor: '#006400',
+    dataPath: resolve(__dirname, '../../../../../data/trc-2025'),
+  },
+  'super-2026': {
+    id: 'super-2026',
+    name: 'Super Rugby Pacific 2026',
+    slug: 'super-2026',
+    sportType: 'rugby-union',
+    primaryColor: '#0047AB',
+    dataPath: resolve(__dirname, '../../../../../data/super-2026'),
+  },
+};
+```
+
+`seed:all` iterates `Object.values(TENANT_CONFIGS)` — adding a third tenant only requires a new config entry, no script changes.
+
+**`getActiveTenantId()` utility:**
+```typescript
+// packages/ui/src/utils/tenant.ts
+// DEV ONLY: reads ?tenant= query param, persists to sessionStorage for SPA navigation
+// In production this code path is never reached — VITE_TENANT_ID is baked at build time
+export function getActiveTenantId(): string {
+  if (import.meta.env.DEV) {
+    const fromUrl = new URLSearchParams(window.location.search).get('tenant');
+    if (fromUrl) {
+      sessionStorage.setItem('spectatr-dev-tenant', fromUrl);
+      return fromUrl;
+    }
+    const fromSession = sessionStorage.getItem('spectatr-dev-tenant');
+    if (fromSession) return fromSession;
+  }
+  return import.meta.env.VITE_TENANT_ID ?? 'trc-2025';
+}
+```
+
+Key properties:
+- **DEV-only guard** — query param / sessionStorage path is completely dead code in production builds
+- **sessionStorage (not localStorage)** — resets on tab close, prevents stale tenant leaking into a new session; isolates per tab
+- **Per-request** — called inside `fetchTrpc()` on every request, so navigating to `?tenant=super-2026` mid-session takes effect immediately
+- **Shareable** — `http://localhost:5173/my-team?tenant=super-2026` works because sessionStorage is seeded on first load and survives React Router navigation
+
+**`super-2026` rounds.json structure (differs from trc-2025):**
+```json
+{
+  "id": 1, "number": 1, "status": "completed",
+  "startDate": "2026-02-13T17:05:00+11:00",
+  "endDate": "2026-02-14T19:35:00+11:00",
+  "tournaments": [
+    { "id": 1, "homeSquadId": 1, "awaySquadId": 2 }
+  ]
+}
+```
+Normalizer maps `number` → `roundNumber`, top-level `status`/`startDate`/`endDate` to `Round` fields. Nested `tournaments` fixture data is discarded for now.
+
+---
+
+## Implementation Tasks
+
+### Phase 1: Schema & Seed Script
+
+- [ ] In `packages/server/prisma/schema.prisma`, remove `@default(42000000)` from `Team.budget`. The column remains; the default is dropped so budget must be supplied explicitly when a team is created (it will come from league rules, not a hardcoded constant).
+- [ ] Run `npm run db:migrate -- --name remove_team_budget_default` to generate and apply the migration.
+- [ ] Read `--tenant <id>` from `process.argv` in `seed.ts`. Default to `trc-2025` when omitted (existing `db:seed` behaviour preserved).
+- [ ] Define `TENANT_CONFIGS` map with both `trc-2025` and `super-2026` entries as above.
+- [ ] Validate the provided tenant ID against `TENANT_CONFIGS`; exit with a clear error if unknown.
+- [ ] Extract all seeding logic into `seedTenant(config: TenantSeedConfig)` so `seed:all` can iterate `Object.values(TENANT_CONFIGS)` automatically.
+- [ ] Add round-format normalizer: detect `tournaments` array vs flat `matches` on each round object; map only top-level round fields to the `Round` upsert.
+- [ ] Merge `data/super-2026/player_stats.json` into each player's `stats` JSONB field during seeding. Store `priceHistory` inside `stats` JSONB.
+- [ ] If `players.json` is an empty array, log `"No players found for {tenantId} — skipping player seeding."` and continue gracefully.
+- [ ] **Squad ID safety:** After upserting each squad, use the DB-returned `id` (not the raw JSON `id`) when linking players — squad ID values overlap between tenants in the source JSON files (both start from 1).
+- [ ] Add to `packages/server/package.json`:
+  - `"seed:trc": "tsx src/scripts/seed.ts --tenant trc-2025"`
+  - `"seed:super": "tsx src/scripts/seed.ts --tenant super-2026"`
+- [ ] Add to root `package.json`: `"seed:all"` that iterates all tenants in a single command.
+- [ ] Verify `trc-2025` seeding still works: `npm run db:seed` (default, no `--tenant` flag).
+
+### Phase 2: Seed super-2026 Data
+
+- [ ] Run `npm run seed:super` and verify:
+  - Tenant record: `id=super-2026`, `name=Super Rugby Pacific 2026`, `slug=super`
+  - 11 Squad records with `tenantId=super-2026`
+  - 16 Round records with `tenantId=super-2026`
+  - 1 GameweekState with `tenantId=super-2026`, `currentRound=1`
+  - 0 Players (expected — `players.json` is empty; warning logged)
+- [ ] Confirm no `trc-2025` data is affected after re-seeding.
+- [ ] Run `npm run seed:all` — both tenants seeded, no duplicate key errors (idempotent).
+
+### Phase 3: Frontend — Tenant Utility + useTenant Hook
+
+- [ ] Create `packages/ui/src/utils/tenant.ts` with `getActiveTenantId()` as defined above.
+- [ ] Create `packages/ui/src/hooks/useTenant.ts`:
+  ```typescript
+  import { getActiveTenantId } from '@/utils/tenant';
+  export function useTenant() {
+    return { tenantId: getActiveTenantId() };
+  }
+  ```
+- [ ] Add `VITE_TENANT_ID=trc-2025` to `packages/ui/env/.env` and `packages/ui/env/.env.example`.
+- [ ] Export `getActiveTenantId` from `packages/ui/src/utils/` barrel (create `index.ts` if absent).
+- [ ] Write unit tests `packages/ui/src/utils/tenant.test.ts`:
+  - Returns `VITE_TENANT_ID` when no query param / sessionStorage present
+  - Returns query param value in DEV mode and writes to sessionStorage
+  - Returns sessionStorage value when no query param (simulates SPA navigation away from `?tenant=` URL)
+  - DEV block is not entered when `import.meta.env.DEV` is false
+
+### Phase 4: Frontend — API Client + Query Cache Keys
+
+- [ ] In `packages/ui/src/hooks/api/client.ts`:
+  - Import `getActiveTenantId` from `@/utils/tenant`
+  - Replace `'x-tenant-id': 'trc-2025'` with `'x-tenant-id': getActiveTenantId()`
+  - Remove the `// TODO: Make this configurable per tenant` comment
+- [ ] Update **all existing query hooks** to include `tenantId` from `useTenant()` in their cache keys:
+  - `['players', tenantId]`, `['squads', tenantId]`, `['gameweek', tenantId]`, etc.
+  - Check `usePlayersQuery`, `useSquadsQuery`, `useGameweekQuery` and any others.
+
+### Phase 5: Frontend — Fix Squad Name Lookups
+
+- [ ] Update `packages/ui/src/features/players/PlayerList.tsx`:
+  - Consume `useSquadsQuery()` to get the current tenant's squads
+  - Pass `squads` as a prop to `PlayerListItem`
+  - Pass `squads` to `FilterPanel` for the squad filter dropdown
+- [ ] Update `packages/ui/src/features/players/PlayerListItem.tsx`:
+  - Add `squads: Squad[]` prop
+  - Replace `getSquadName(player.squadId)` with `squads.find(s => s.id === player.squadId)?.name ?? 'Unknown'`
+  - Remove the static `getSquadName` import from `@/mocks/playerData`
+- [ ] Check `FilterPanel.tsx` — if it imports a static squad list, update it to accept squads as a prop.
+- [ ] In `packages/ui/src/mocks/playerData.ts`, mark `getSquadById` / `getSquadName` as `@deprecated — Use API squads from useSquadsQuery instead`. Do not delete (Storybook stories may still depend on them).
+- [ ] Update the `PlayerListItem` Storybook story to pass `squads` as an explicit prop instead of relying on the deprecated static helper.
+
+### Phase 6: Store Reset on Tenant Switch
+
+- [ ] In `myTeamStore` (and any other store holding tenant-scoped data), store the `tenantId` when persisting state.
+- [ ] On store initialisation, compare the persisted `tenantId` with `getActiveTenantId()`. If they differ, reset the store to its initial state and write the new `tenantId`.
+- [ ] Verify: select players in `trc-2025`, switch to `?tenant=super-2026`, reload — squad should be empty in the super-2026 session.
+
+### Phase 7: Documentation
+
+- [ ] Update `packages/server/START.md`:
+  - Add multi-tenant seeding steps (`seed:trc`, `seed:super`, `seed:all`)
+  - Note that `db:seed` without `--tenant` still defaults to `trc-2025`
+- [ ] Update `ARCHITECTURE.md` tenant section:
+  - Add `VITE_TENANT_ID` env var
+  - Add `?tenant=` dev override with sessionStorage behaviour and per-tab isolation
+  - Add production Cloudflare header injection pattern
+- [ ] Create `docs/PLAYER_IMAGES.md` — document the image naming incompatibility between tenants, the current 404 consequence for super-2026 players, and constraints the future image plan must address:
+  - Tenant-scoped subdirectory approach (`/player-images/{tenantId}/`)
+  - Migration cost for existing trc-2025 images
+  - Fallback/placeholder image strategy
+  - `getPlayerPitchImage()` / `getPlayerProfileImage()` must become tenant-aware
+
+---
+
+## Open Questions
+
+### 1. super-2026/players.json — Scope of this plan?
+
+`super-2026/players.json` is currently empty. Seeding squads + rounds is sufficient to validate the multi-tenant infrastructure. Populating player data is a data task independent of this plan.
+
+> **Decision: Seeding squads + rounds is sufficient to close this plan.** Player data is deferred.
+
+### 2. Squad ID collisions
+
+`trc-2025` squads have IDs 1–4 in the source JSON; `super-2026` squads also start from 1. The DB upserts by `[tenantId, abbreviation]` so there is no conflict — but the seed script must use the DB-returned `id` after upsert, not the raw JSON `id`, when writing `squadId` on player records.
+
+> **Action: Verify the existing trc-2025 seed script already does this correctly, and carry the pattern forward for super-2026.**
+
+### 3. super-2026 rounds nested fixture data
+
+`tournaments` array contains full fixture data (venue, score, status) with no equivalent in the `Round` model.
+
+> **Decision: Normalize to the existing `Round` model shape.** Discard venue/score/status for now. Revisit when `ScoringEvent` seeding is planned.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- `tenant.test.ts` — 4 branches: query param (DEV), sessionStorage (DEV), env var, DEV guard off
+- Round-format normalizer — unit test with both round schemas (trc-2025 flat, super-2026 with tournaments)
+
+### Seed Integration
+
+- Seed both tenants → verify DB row counts in `Tenant`, `Squad`, `Round`, `GameweekState`
+- Re-run `seed:all` → no errors (idempotent upserts)
+- Verify trc-2025 player/squad data unchanged after re-seeding
+
+### Frontend Integration
+
+- Load `?tenant=super-2026` → Network tab: `x-tenant-id: super-2026` on all tRPC requests
+- Navigate to `/my-team` (no query param in URL) → sessionStorage keeps `x-tenant-id: super-2026`
+- Open new tab without query param → defaults to `trc-2025`
+- Player list with `?tenant=super-2026` → 11 Super Rugby squads, empty player list (no crash)
+- Player list with `?tenant=trc-2025` → correct squad names via API (not static mock)
+- Select players in `trc-2025`, switch to `?tenant=super-2026` → `myTeamStore` is empty
+
+### Storybook
+
+- `PlayerListItem` stories pass `squads` prop explicitly (no dependency on deprecated static helper)
+- All existing stories still pass
+
+---
+
+## Success Criteria
+
+- [ ] `npm run seed:all` iterates both tenants from `TENANT_CONFIGS`; succeeds with no errors
+- [ ] `npm run seed:trc` and `npm run seed:super` both work independently
+- [ ] DB contains correct rows for both tenants; re-run is idempotent
+- [ ] `?tenant=super-2026` causes all tRPC requests to send `x-tenant-id: super-2026`
+- [ ] Tenant param survives React Router navigation within the same tab (sessionStorage)
+- [ ] New tab without query param reverts to `trc-2025`
+- [ ] `VITE_TENANT_ID` env var sets the session default when no query param present
+- [ ] All TanStack Query cache keys include `tenantId`
+- [ ] No `getSquadName` calls depend on static `trc-2025/squads.json` at runtime
+- [ ] `myTeamStore` resets when tenant changes
+- [ ] All `tenant.test.ts` unit tests pass
+- [ ] All existing Storybook stories pass
+- [ ] No TypeScript errors, no `any` types introduced
+- [ ] Production build: DEV-only code path is tree-shaken (`import.meta.env.DEV` guard)
+- [ ] Player image constraint documented in `docs/PLAYER_IMAGES.md`
+- [ ] `Team.budget` DB default removed; migration applied cleanly
+
+---
+
+## Decisions
+
+- **`seed:all` iterates `TENANT_CONFIGS`** — adding a third tenant only requires a new config entry, no script changes
+- **`useTenant()` is the single source of tenant identity** across query cache keys and UI display (AppBar, SettingsDialog, etc.)
+- **sessionStorage over localStorage** — clears on tab close, isolates per tab, no stale override leaking into a new session
+- **`import.meta.env.DEV` guard** — query param path is dead code in production; a prod user appending `?tenant=` is structurally ignored
+- **API-sourced squad lookups over tenant-aware mock registry** — mocks are for Storybook/offline dev only; fixing the root cause is cleaner than maintaining a parallel tenant-aware mock registry
+- **`priceHistory` + `player_stats.json` in `stats` JSONB** — no schema migration; revisit if filtering/querying by price history becomes a requirement
+- **Store reset on tenant mismatch at initialisation** — deterministic, runs once at startup, no runtime overhead
+- **No in-app tenant switcher UI** — tenant identity comes from outside the app (URL/env/CDN), not from application state; no Zustand store, no SettingsDialog changes
+- **`db:seed` default preserved** — `trc-2025` default ensures existing `START.md` onboarding flow is unchanged
+
+---
+
+## Notes
+
+- **Jira ticket:** FSA-TBD
+- **Image plan dependency:** `super-2026` players will show broken/missing images until the player image plan is implemented — acceptable for this infrastructure milestone
+- **Sport config:** Both tenants are `rugby-union` — no `getSportConfig` changes needed
+- **Team budget default removed** — `@default(42000000)` dropped from `Team.budget`; no code currently reads it back, and budget cap will come from `League.rules` when teams are implemented
+- **`priceHistory` storage:** Stored in `stats` JSONB with no migration. Revisit if querying/filtering by price history becomes a requirement.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "build:ui": "npm run build --workspace=@spectatr/ui",
     "build:server": "npm run build --workspace=@spectatr/server",
     "lint": "npm run lint --workspaces",
-    "preview": "npm run preview --workspace=@spectatr/ui"
+    "preview": "npm run preview --workspace=@spectatr/ui",
+    "seed:trc": "npm run seed:trc --workspace=@spectatr/server",
+    "seed:super": "npm run seed:super --workspace=@spectatr/server",
+    "seed:all": "npm run seed:all --workspace=@spectatr/server"
   },
   "engines": {
     "node": ">=20.0.0",

--- a/packages/server/env/.env.example
+++ b/packages/server/env/.env.example
@@ -9,7 +9,10 @@ PORT=3001
 
 # Database connection string
 # Format: postgresql://username:password@host:port/database
+# Use postgres (superuser) for migrations and seeds only.
+# Use spectatr_app for runtime API connections (enforces RLS policies).
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/spectatr
+# DATABASE_URL=postgresql://spectatr_app:spectatr_app@localhost:5432/spectatr
 
 # Redis connection (for BullMQ background jobs)
 REDIS_HOST=localhost

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,6 +12,9 @@
     "db:migrate": "prisma migrate dev --env-file env/.env",
     "db:migrate:deploy": "prisma migrate deploy --env-file env/.env",
     "db:seed": "tsx src/scripts/seed.ts",
+    "seed:trc": "tsx src/scripts/seed.ts --tenant trc-2025",
+    "seed:super": "tsx src/scripts/seed.ts --tenant super-2026",
+    "seed:all": "tsx src/scripts/seed.ts --all",
     "db:studio": "prisma studio --env-file env/.env",
     "db:reset": "prisma migrate reset --env-file env/.env",
     "lint": "eslint ."

--- a/packages/server/prisma/migrations/20260221225959_remove_team_budget_default/migration.sql
+++ b/packages/server/prisma/migrations/20260221225959_remove_team_budget_default/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "teams" ALTER COLUMN "budget" DROP DEFAULT;

--- a/packages/server/prisma/migrations/20260222000000_add_rls/migration.sql
+++ b/packages/server/prisma/migrations/20260222000000_add_rls/migration.sql
@@ -1,0 +1,96 @@
+-- ============================================================
+-- Row Level Security (RLS) for tenant isolation
+--
+-- Strategy:
+--  1. Create a `spectatr_app` role used by all runtime connections.
+--     The `postgres` superuser retains full access (no RLS) so seeds
+--     and migrations continue to work without changes.
+--  2. Enable RLS on every table that carries a `tenantId` column.
+--  3. Create a PERMISSIVE policy that allows rows where `tenantId`
+--     matches the session variable `app.current_tenant`.
+--     The application sets this variable via `SET LOCAL` before each
+--     query (see createTenantScopedPrisma in context.ts).
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. App role
+-- ------------------------------------------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'spectatr_app') THEN
+    CREATE ROLE spectatr_app LOGIN PASSWORD 'spectatr_app';
+  END IF;
+END
+$$;
+
+-- Grant schema and sequence usage
+GRANT USAGE ON SCHEMA public TO spectatr_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO spectatr_app;
+
+-- Grant table-level permissions
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO spectatr_app;
+
+-- Ensure future tables are also covered
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO spectatr_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO spectatr_app;
+
+-- ------------------------------------------------------------
+-- 2. Enable RLS on tenant-scoped tables
+-- ------------------------------------------------------------
+ALTER TABLE squads          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE players         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tournaments     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE rounds          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE gameweek_states ENABLE ROW LEVEL SECURITY;
+ALTER TABLE scoring_events  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE checksums       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE leagues         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE teams           ENABLE ROW LEVEL SECURITY;
+
+-- ------------------------------------------------------------
+-- 3. Policies — applied to spectatr_app role only
+--
+-- current_setting('app.current_tenant', true) returns NULL when the
+-- variable is not set (second arg = true → no error).
+-- The policy intentionally DENIES access when the variable is unset,
+-- forcing every runtime query to go through createTenantScopedPrisma.
+-- The postgres superuser bypasses RLS automatically.
+-- ------------------------------------------------------------
+
+CREATE POLICY tenant_isolation ON squads
+  FOR ALL TO spectatr_app
+  USING ("tenantId" = current_setting('app.current_tenant', true));
+
+CREATE POLICY tenant_isolation ON players
+  FOR ALL TO spectatr_app
+  USING ("tenantId" = current_setting('app.current_tenant', true));
+
+CREATE POLICY tenant_isolation ON tournaments
+  FOR ALL TO spectatr_app
+  USING ("tenantId" = current_setting('app.current_tenant', true));
+
+CREATE POLICY tenant_isolation ON rounds
+  FOR ALL TO spectatr_app
+  USING ("tenantId" = current_setting('app.current_tenant', true));
+
+CREATE POLICY tenant_isolation ON gameweek_states
+  FOR ALL TO spectatr_app
+  USING ("tenantId" = current_setting('app.current_tenant', true));
+
+CREATE POLICY tenant_isolation ON scoring_events
+  FOR ALL TO spectatr_app
+  USING ("tenantId" = current_setting('app.current_tenant', true));
+
+CREATE POLICY tenant_isolation ON checksums
+  FOR ALL TO spectatr_app
+  USING ("tenantId" = current_setting('app.current_tenant', true));
+
+CREATE POLICY tenant_isolation ON leagues
+  FOR ALL TO spectatr_app
+  USING ("tenantId" = current_setting('app.current_tenant', true));
+
+CREATE POLICY tenant_isolation ON teams
+  FOR ALL TO spectatr_app
+  USING ("tenantId" = current_setting('app.current_tenant', true));

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -291,7 +291,7 @@ model Team {
   userId    String
   leagueId  Int
   name      String
-  budget    Int      @default(42000000) // Budget in cents
+  budget    Int
   totalCost Int      @default(0)
   points    Int      @default(0)
   rank      Int?

--- a/packages/ui/env/.env
+++ b/packages/ui/env/.env
@@ -4,3 +4,5 @@
 # Clerk Authentication
 # Get this from https://dashboard.clerk.com
 VITE_CLERK_PUBLISHABLE_KEY=pk_test_cmVhZHktc2hyZXctNTAuY2xlcmsuYWNjb3VudHMuZGV2JA
+# Active tenant for this deployment (e.g. trc-2025, super-2026)
+VITE_TENANT_ID=trc-2025

--- a/packages/ui/env/.env.example
+++ b/packages/ui/env/.env.example
@@ -4,3 +4,5 @@
 # Clerk Authentication
 # Get this from https://dashboard.clerk.com
 VITE_CLERK_PUBLISHABLE_KEY=pk_test_xxx
+# Active tenant for this deployment (e.g. trc-2025, super-2026)
+VITE_TENANT_ID=trc-2025

--- a/packages/ui/src/hooks/api/client.ts
+++ b/packages/ui/src/hooks/api/client.ts
@@ -1,4 +1,5 @@
 import { API_CONFIG } from '@/config/constants';
+import { getActiveTenantId } from '@/utils/tenant';
 
 interface TrpcResponse<T> {
   result: {
@@ -26,7 +27,7 @@ export async function fetchTrpc<T>(
 
   const headers: HeadersInit = {
     'Content-Type': 'application/json',
-    'x-tenant-id': 'trc-2025', // TODO: Make this configurable per tenant
+    'x-tenant-id': getActiveTenantId(),
   };
 
   // Add auth token if available

--- a/packages/ui/src/hooks/api/index.ts
+++ b/packages/ui/src/hooks/api/index.ts
@@ -5,6 +5,8 @@ export { useGameweekQuery } from './useGameweekQuery';
 export { useChecksumQuery } from './useChecksumQuery';
 export { useChecksumPoller } from './useChecksumPoller';
 export { useTrpcClient } from './useTrpcClient';
+export { useTenantQuery } from './useTenantQuery';
+export { useTenant } from '@/hooks/useTenant';
 
 export type { PlayersQueryInput, PlayersQueryResult } from './usePlayersQuery';
 export type { GameweekStatus, GameweekState } from './useGameweekQuery';

--- a/packages/ui/src/hooks/api/useChecksumQuery.ts
+++ b/packages/ui/src/hooks/api/useChecksumQuery.ts
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
 import { useTrpcClient } from './useTrpcClient';
+import { useTenantQuery } from './useTenantQuery';
 
 export interface ChecksumResponse {
   version: number;
@@ -18,7 +18,7 @@ export interface ChecksumResponse {
 export const useChecksumQuery = () => {
   const trpc = useTrpcClient();
   
-  return useQuery({
+  return useTenantQuery({
     queryKey: ['checksum', 'current'],
     queryFn: () => trpc<ChecksumResponse>('checksum.current'),
     staleTime: 0, // Always consider stale for accurate polling

--- a/packages/ui/src/hooks/api/useGameweekQuery.ts
+++ b/packages/ui/src/hooks/api/useGameweekQuery.ts
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
 import { useTrpcClient } from './useTrpcClient';
+import { useTenantQuery } from './useTenantQuery';
 
 export type GameweekStatus = 'pre_round' | 'active' | 'locked' | 'processing' | 'complete';
 
@@ -17,7 +17,7 @@ export interface GameweekState {
 export const useGameweekQuery = () => {
   const trpc = useTrpcClient();
   
-  return useQuery({
+  return useTenantQuery({
     queryKey: ['gameweek', 'current'],
     queryFn: () => trpc<GameweekState>('gameweek.current'),
     staleTime: 5 * 60 * 1000, // 5 minutes - gameweek state changes infrequently

--- a/packages/ui/src/hooks/api/usePlayersQuery.ts
+++ b/packages/ui/src/hooks/api/usePlayersQuery.ts
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
 import { useTrpcClient } from './useTrpcClient';
+import { useTenantQuery } from './useTenantQuery';
 import type { Player } from '@/mocks/playerData';
 
 export interface PlayersQueryInput {
@@ -28,7 +28,7 @@ export const usePlayersQuery = (input: PlayersQueryInput = {}) => {
     ? (Object.fromEntries(entries) as PlayersQueryInput)
     : undefined;
 
-  return useQuery({
+  return useTenantQuery({
     queryKey: ['players', cleanInput ?? {}],
     queryFn: () => trpc<PlayersQueryResult>('players.list', cleanInput as Record<string, unknown> | undefined),
     staleTime: 60 * 1000,

--- a/packages/ui/src/hooks/api/useRoundsQuery.ts
+++ b/packages/ui/src/hooks/api/useRoundsQuery.ts
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
 import { useTrpcClient } from './useTrpcClient';
+import { useTenantQuery } from './useTenantQuery';
 
 export interface Round {
   id: number;
@@ -24,7 +24,7 @@ export interface RoundsQueryResult {
 export const useRoundsQuery = () => {
   const trpc = useTrpcClient();
   
-  return useQuery({
+  return useTenantQuery({
     queryKey: ['rounds'],
     queryFn: () => trpc<RoundsQueryResult>('rounds.list'),
     staleTime: 60 * 1000,

--- a/packages/ui/src/hooks/api/useSquadsQuery.ts
+++ b/packages/ui/src/hooks/api/useSquadsQuery.ts
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
 import { useTrpcClient } from './useTrpcClient';
+import { useTenantQuery } from './useTenantQuery';
 
 export interface Squad {
   id: number;
@@ -15,7 +15,7 @@ export interface Squad {
 export const useSquadsQuery = () => {
   const trpc = useTrpcClient();
   
-  return useQuery({
+  return useTenantQuery({
     queryKey: ['squads'],
     queryFn: () => trpc<Squad[]>('squads.list'),
     staleTime: 24 * 60 * 60 * 1000,

--- a/packages/ui/src/hooks/api/useTenantQuery.ts
+++ b/packages/ui/src/hooks/api/useTenantQuery.ts
@@ -1,0 +1,33 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { useTenant } from '@/hooks/useTenant';
+
+/**
+ * Drop-in replacement for `useQuery` that automatically prefixes every query
+ * key with the active tenant ID.
+ *
+ * This means:
+ *  - Individual query hooks don't need to import or call `useTenant` — the
+ *    tenant concern is handled here, once.
+ *  - Switching tenant invalidates all cached data automatically because the
+ *    keys are different (e.g. `['trc-2025', 'players', ...]` vs
+ *    `['super-2026', 'players', ...]`).
+ *
+ * @example
+ * // Before
+ * const { tenantId } = useTenant();
+ * useQuery({ queryKey: ['players', tenantId, input], ... });
+ *
+ * // After
+ * useTenantQuery({ queryKey: ['players', input], ... });
+ */
+export function useTenantQuery<
+  TData,
+  TError = Error,
+>(options: UseQueryOptions<TData, TError>) {
+  const { tenantId } = useTenant();
+
+  return useQuery<TData, TError>({
+    ...options,
+    queryKey: [tenantId, ...options.queryKey],
+  });
+}

--- a/packages/ui/src/hooks/useTenant.ts
+++ b/packages/ui/src/hooks/useTenant.ts
@@ -1,0 +1,13 @@
+import { getActiveTenantId } from '@/utils/tenant';
+
+/**
+ * React hook that returns the active tenant ID.
+ * Reads from query param (DEV), sessionStorage (DEV), or env var.
+ *
+ * @example
+ * const { tenantId } = useTenant();
+ */
+export function useTenant(): { tenantId: string } {
+  // getActiveTenantId() is a pure synchronous function — safe to call in render
+  return { tenantId: getActiveTenantId() };
+}

--- a/packages/ui/src/mocks/playerData.ts
+++ b/packages/ui/src/mocks/playerData.ts
@@ -14,14 +14,26 @@ export interface PlayerSquad {
 
 export const squads: PlayerSquad[] = squadsData;
 
+/**
+ * @deprecated Uses hardcoded trc-2025 squads. Use `useSquadsQuery()` from
+ * `@/hooks/api` to fetch squads for the active tenant at runtime.
+ */
 export function getSquadById(squadId: number): PlayerSquad | undefined {
     return squads.find(squad => squad.id === squadId);
 }
 
+/**
+ * @deprecated Uses hardcoded trc-2025 squads. Use `useSquadsQuery()` from
+ * `@/hooks/api` to fetch squads for the active tenant at runtime.
+ */
 export function getSquadName(squadId: number): string {
     return getSquadById(squadId)?.name || 'Unknown';
 }
 
+/**
+ * @deprecated Uses hardcoded trc-2025 squads. Use `useSquadsQuery()` from
+ * `@/hooks/api` to fetch squads for the active tenant at runtime.
+ */
 export function getSquadAbbreviation(squadId: number): string {
     return getSquadById(squadId)?.abbreviation || 'N/A';
 }

--- a/packages/ui/src/stores/myTeamStore.ts
+++ b/packages/ui/src/stores/myTeamStore.ts
@@ -4,6 +4,7 @@ import type { Player } from '../mocks/playerData';
 import { getMaxPlayerCost } from '../mocks/playerData';
 import { VALIDATION, STORAGE_KEYS } from '../config/constants';
 import { getPositionsByType, getAllPositions } from '../config/fieldLayouts';
+import { getActiveTenantId } from '../utils/tenant';
 
 // Calculate max price from actual player data
 const MAX_PLAYER_PRICE = Math.ceil(getMaxPlayerCost() / 1_000_000);
@@ -236,7 +237,9 @@ export const useMyTeamStore = create<MyTeamState>()(
         }),
     }),
     {
-      name: STORAGE_KEYS.MY_TEAM,
+      // Scope the persistence key to the active tenant so each tenant
+      // (trc-2025, super-2026, …) maintains an independent squad.
+      name: `${STORAGE_KEYS.MY_TEAM}:${getActiveTenantId()}`,
       partialize: (state) => ({
         slots: state.slots,
         totalCost: state.totalCost,

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -1,1 +1,2 @@
 export { migrateLocalStorage, cleanupOldLocalStorageKeys, isMigrationNeeded } from './migrations';
+export { getActiveTenantId } from './tenant';

--- a/packages/ui/src/utils/tenant.test.ts
+++ b/packages/ui/src/utils/tenant.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getActiveTenantId } from './tenant';
+
+/**
+ * Unit tests for getActiveTenantId()
+ *
+ * We test the four resolution branches:
+ *  1. DEV + query param  → returns param value & persists to sessionStorage
+ *  2. DEV + sessionStorage only  → returns stored value
+ *  3. DEV guard off (production) → uses VITE_TENANT_ID env var
+ *  4. No env var set  → throws an error
+ */
+
+// Helper to reset sessionStorage between tests
+const clearSession = () => sessionStorage.clear();
+
+describe('getActiveTenantId', () => {
+  beforeEach(() => {
+    clearSession();
+    // Reset URL to no query params
+    Object.defineProperty(globalThis, 'location', {
+      writable: true,
+      value: { search: '' },
+    });
+  });
+
+  afterEach(() => {
+    clearSession();
+    vi.unstubAllEnvs();
+  });
+
+  it('DEV: reads ?tenant= query param, persists to sessionStorage, and returns it', () => {
+    vi.stubEnv('DEV', true);
+    Object.defineProperty(globalThis, 'location', {
+      writable: true,
+      value: { search: '?tenant=super-2026' },
+    });
+
+    const result = getActiveTenantId();
+
+    expect(result).toBe('super-2026');
+    expect(sessionStorage.getItem('spectatr_tenant_id')).toBe('super-2026');
+  });
+
+  it('DEV: returns sessionStorage value when no query param present', () => {
+    vi.stubEnv('DEV', true);
+    sessionStorage.setItem('spectatr_tenant_id', 'super-2026');
+
+    const result = getActiveTenantId();
+
+    expect(result).toBe('super-2026');
+  });
+
+  it('DEV fallback: returns VITE_TENANT_ID when neither query param nor session present', () => {
+    vi.stubEnv('DEV', true);
+    vi.stubEnv('VITE_TENANT_ID', 'trc-2025');
+
+    const result = getActiveTenantId();
+
+    expect(result).toBe('trc-2025');
+  });
+
+  it('throws when VITE_TENANT_ID is not set', () => {
+    vi.stubEnv('DEV', false);
+    vi.stubEnv('VITE_TENANT_ID', '');
+
+    expect(() => getActiveTenantId()).toThrow('VITE_TENANT_ID is not set');
+  });
+});

--- a/packages/ui/src/utils/tenant.ts
+++ b/packages/ui/src/utils/tenant.ts
@@ -1,0 +1,44 @@
+/**
+ * Tenant resolution utility
+ *
+ * Priority order:
+ *  1. DEV ONLY: `?tenant=<id>` query param → persisted to sessionStorage for SPA navigation
+ *  2. DEV ONLY: sessionStorage key `spectatr_tenant_id` (set by step 1)
+ *  3. All modes: `VITE_TENANT_ID` env var (baked in at build time)
+ *
+ * Notes:
+ * - The query-param / sessionStorage path is compiled out in production builds
+ *   (import.meta.env.DEV is false → dead code eliminated by Vite/Rollup).
+ * - sessionStorage (not localStorage) is intentional: resets on tab close,
+ *   prevents stale tenant leaking into a new session, and isolates per tab.
+ * - Calling `?tenant=super-2026` once is enough — sessionStorage survives
+ *   React Router navigation within the same tab.
+ */
+
+const SESSION_KEY = 'spectatr_tenant_id';
+
+export function getActiveTenantId(): string {
+  if (import.meta.env.DEV) {
+    // Check for ?tenant= query param and persist it
+    const params = new URLSearchParams(window.location.search);
+    const queryTenant = params.get('tenant');
+    if (queryTenant) {
+      sessionStorage.setItem(SESSION_KEY, queryTenant);
+      return queryTenant;
+    }
+
+    // Check sessionStorage (set on a previous navigation within this tab)
+    const stored = sessionStorage.getItem(SESSION_KEY);
+    if (stored) {
+      return stored;
+    }
+  }
+
+  const tenantId = import.meta.env.VITE_TENANT_ID;
+  if (!tenantId) {
+    throw new Error(
+      'VITE_TENANT_ID is not set. Add it to packages/ui/env/.env (e.g. VITE_TENANT_ID=trc-2025).'
+    );
+  }
+  return tenantId;
+}

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -44,6 +44,7 @@ export default defineConfig({
         }
       },
       {
+        extends: true,
         // Unit test project for pure functions and store logic
         test: {
           name: 'unit',


### PR DESCRIPTION
Adds a second tenant (`super-2026`), hardens tenant data isolation with PostgreSQL RLS + Prisma app-level filtering, and introduces a frontend tenant-switching mechanism for development.

---

## Changes

### 🌱 Multi-tenant seed data
- Added `data/super-2026/` — Super Rugby Pacific 2026 (441 players, 11 squads, 16 rounds)
- Seed script updated to support `--tenant <id>` and `--all` flags
- `npm run db:seed -- --tenant trc-2025` or `npm run db:seed -- --all`

### 🔐 Dual-layer tenant isolation (backend)
New migration `20260222000000_add_rls`:
- Creates `spectatr_app` PostgreSQL role with DML permissions
- Enables Row Level Security on all tenant-scoped tables (`squads`, `players`, `tournaments`, `rounds`, `gameweek_states`, `scoring_events`, `checksums`, `leagues`, `teams`)
- Policies enforce `"tenantId" = current_setting('app.current_tenant', true)` for the `spectatr_app` role

`createTenantScopedPrisma` in `context.ts` now applies both layers:

| Layer | When enforced | Mechanism |
|---|---|---|
| PostgreSQL RLS | `spectatr_app` role | `SET LOCAL "app.current_tenant"` per query |
| Prisma app-level | Always (incl. `postgres` superuser) | `tenantId` injected into every `where`/`create`/`update` |

Seeds and migrations continue to use the `postgres` superuser and bypass RLS intentionally.

> To enable DB-level RLS for the runtime server, set `DATABASE_URL=postgresql://spectatr_app:spectatr_app@localhost:5432/spectatr` in `packages/server/env/.env`

### 🔀 Frontend tenant switching
- `utils/tenant.ts` — `getActiveTenantId()` resolves tenant via: `?tenant=` query param → sessionStorage → `VITE_TENANT_ID` env var
- `useTenant` hook — React wrapper around `getActiveTenantId()`
- `useTenantQuery` — Drop-in for `useQuery` that auto-prefixes all cache keys with `tenantId`. Switching tenant automatically invalidates cached data. All query hooks updated to use this.

**Dev switching:** append `?tenant=super-2026` once — sessionStorage persists it for the tab.

---

## Testing

```bash
# Seed both tenants
npm run db:seed -- --all
